### PR TITLE
fix: assign load_result() to a variable

### DIFF
--- a/insert_by_period/macros/insert_by_period_materialization.sql
+++ b/insert_by_period/macros/insert_by_period_materialization.sql
@@ -54,15 +54,18 @@
     {%- endcall %}
   {%- endif %}
 
-  {% set _ = insert_by_period.get_period_boundaries(schema,
-                                              identifier,
-                                              timestamp_field,
-                                              start_date,
-                                              stop_date,
-                                              period) %}
-  {%- set start_timestamp = load_result('period_boundaries')['data'][0][0] | string -%}
-  {%- set stop_timestamp = load_result('period_boundaries')['data'][0][1] | string -%}
-  {%- set num_periods = load_result('period_boundaries')['data'][0][2] | int -%}
+  {% set period_boundaries = insert_by_period.get_period_boundaries(
+    schema,
+    identifier,
+    timestamp_field,
+    start_date,
+    stop_date,
+    period
+  ) %}
+  {% set period_boundaries_results = load_result('period_boundaries')['data'][0] %}
+  {%- set start_timestamp = period_boundaries_results[0] | string -%}
+  {%- set stop_timestamp = period_boundaries_results[1] | string -%}
+  {%- set num_periods = period_boundaries_results[2] | int -%}
 
   {% set target_columns = adapter.get_columns_in_relation(target_relation) %}
   {%- set target_cols_csv = target_columns | map(attribute='quoted') | join(', ') -%}


### PR DESCRIPTION
## Purpose
The `insert_by_period` materialization is not compatible with dbt 1.6 due to load_result() not being set on initial call. This PR will fix that.

## Problem
```
❯ dbt build -s test_insert_by_period                                                                                
15:38:59  Running with dbt=1.6.0                          
15:38:59  Registered adapter: redshift=1.6.0              
15:39:09  Found 5 snapshots, 482 tests, 73 seeds, 2 operations, 1324 models, 42 analyses, 450 sources, 456 exposures, 0 metrics, 893 macros, 0 groups, 0 semantic models
15:39:09                                                                                                            
15:39:11  Concurrency: 8 threads (target='dev')
15:39:11                                                  
15:39:11  1 of 1 START sql insert_by_period model dbt_thoren.test_insert_by_period ....... [RUN]
15:39:12  1 of 1 ERROR creating sql insert_by_period model dbt_thoren.test_insert_by_period  [ERROR in 0.90s] 
15:39:12                                                  
15:39:12  Running 2 on-run-end hooks                    
15:39:12  1 of 2 START hook: tj.on-run-end.0 ............................................. [RUN]
15:39:12  1 of 2 OK hook: tj.on-run-end.0 ................................................ [OK in 0.00s]
15:39:12  2 of 2 START hook: tj.on-run-end.1 ............................................. [RUN]
15:39:12  2 of 2 OK hook: tj.on-run-end.1 ................................................ [OK in 0.00s]
15:39:12  
15:39:12  
15:39:12  Finished running 1 insert_by_period model, 2 hooks in 0 hours 0 minutes and 3.39 seconds (3.39s).
15:39:13  
15:39:13  Completed with 1 error and 0 warnings:
15:39:13  
15:39:13  Compilation Error in model test_insert_by_period (models/test_insert_by_period.sql)
15:39:13    The 'statement' result named 'period_boundaries' has already been loaded into a variable
15:39:13    
15:39:13    > in macro materialization_insert_by_period_default (macros/insert_by_period_materialization.sql)
15:39:13    > called by model test_insert_by_period (models/test_insert_by_period.sql)
15:39:13  
15:39:13  Done. PASS=0 WARN=0 ERROR=1 SKIP=0 TOTAL=1
```
## Validation
```
❯ dbt build -s test_insert_by_period
15:53:22  Running with dbt=1.6.0
15:53:22  Registered adapter: redshift=1.6.0
15:53:24  Found 5 snapshots, 482 tests, 73 seeds, 2 operations, 1324 models, 42 analyses, 450 sources, 456 exposures, 0 metrics, 893 macros, 0 groups, 0 semantic models
15:53:24
15:53:26  Concurrency: 8 threads (target='dev')
15:53:26
15:53:26  1 of 1 START sql insert_by_period model dbt_thoren.test_insert_by_period ....... [RUN]
Running for day 1 of 14
Ran for day 1 of 14; 1 records inserted
Running for day 2 of 14
Ran for day 2 of 14; 1 records inserted
Running for day 3 of 14
Ran for day 3 of 14; 2 records inserted
Running for day 4 of 14
Ran for day 4 of 14; 1 records inserted
Running for day 5 of 14
Ran for day 5 of 14; 1 records inserted
Running for day 6 of 14
Ran for day 6 of 14; 2 records inserted
Running for day 7 of 14
Ran for day 7 of 14; 1 records inserted
Running for day 8 of 14
Ran for day 8 of 14; 1 records inserted
Running for day 9 of 14
Ran for day 9 of 14; 1 records inserted
Running for day 10 of 14
Ran for day 10 of 14; 1 records inserted
Running for day 11 of 14
Ran for day 11 of 14; 2 records inserted
Running for day 12 of 14
Ran for day 12 of 14; 1 records inserted
Running for day 13 of 14
Ran for day 13 of 14; 1 records inserted
Running for day 14 of 14
Ran for day 14 of 14; 1 records inserted
15:55:00  1 of 1 OK created sql insert_by_period model dbt_thoren.test_insert_by_period .. [INSERT 17 in 94.54s]
15:55:01
15:55:01  Running 2 on-run-end hooks
15:55:01  1 of 2 START hook: tj.on-run-end.0 ............................................. [RUN]
15:55:01  1 of 2 OK hook: tj.on-run-end.0 ................................................ [OK in 0.00s]
15:55:01  2 of 2 START hook: tj.on-run-end.1 ............................................. [RUN]
15:55:01  2 of 2 OK hook: tj.on-run-end.1 ................................................ [OK in 0.00s]
15:55:01
15:55:01
15:55:01  Finished running 1 insert_by_period model, 2 hooks in 0 hours 1 minutes and 37.03 seconds (97.03s).
15:55:01
15:55:01  Completed successfully
15:55:01
15:55:01  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```